### PR TITLE
Have time stepsize the length of a week

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,7 +62,7 @@ function render(key, rawData) {
                     type: 'time',
                     display: true,
                     time: {
-                        stepSize: 5
+                        stepSize: 7
                     }
                 }],
                 yAxes: [{


### PR DESCRIPTION
set stepsize to 7 for time on x-axis

This makes week boundaries and weekly flactuations more visible.

Weekends has effects on the reporting, with less cases being reported. So the number tends to oscilate a bit. This is described in this thread: https://twitter.com/pavel23/status/1275046124282355713  
Having the stepsizes the length of a week, makes this a bit more visible.