### PR TITLE
remove horizontal-scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,3 +12,8 @@ ul {
     padding: 0;
     list-style: none;
 }
+
+.row {
+    margin-right: 0;
+    margin-left: 0;
+}


### PR DESCRIPTION
Hi, this change is for a small discussion. 

I noticed on Desktop and Mobile that the page has a bit of unintended horizontal scrolling. On short-notice I couldn't see where this comes from, the markup and usage of bootstrap looks correct, but by removing these two margins, the scrolling disappears. Maybe you have an idea if there is any place I miss that may mess with this margin.